### PR TITLE
Bug fix

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -14,7 +14,8 @@ pd.set_option('mode.use_inf_as_na', False)
 
 # Configs streamlit
 st.set_page_config(page_title="Círculo de Compensação Nacional")
-st.markdown(""" # Custom CSS rules for better year select display and text links
+# Custom CSS rules for better year select display and text links
+st.markdown("""
     <style>
         .stSelectbox * { cursor: pointer !important; }
         .stSelectbox div[value] { color: black; }


### PR DESCRIPTION
Agora ao ver em produção reparei que havia escrito um comentário de estilo Python dentro do CSS, surgindo como título da página:

<img width="425" alt="screenshot 2023-10-09 at 12 45 46" src="https://github.com/pedroschuller/circulo_compensacao/assets/1041/c32451d3-2abc-4a3d-a058-3545151c4062">   

Esta versão corrige tal.